### PR TITLE
update sinatra default port

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -1,6 +1,7 @@
 require 'sinatra'
 
 set :bind, '0.0.0.0'
+set :port, 8080
 
 get '/' do
   name = ENV['NAME'] || 'World'


### PR DESCRIPTION
Change sinatra default port to match flyio's required 8080 port

the default 4567 port was raising : 
```
 == Sinatra (v2.0.7) has taken the stage on 4567 for development with backup from WEBrick
[2020-03-20 10:41:41] INFO  WEBrick::HTTPServer#start: pid=553 port=4567
Health check status changed to 'critical' => dial tcp 172.18.156.44:8080: connect: connection refused
[2020-03-20T10:42:16Z] Sending signal SIGINT to pid 553
 == Sinatra has ended his set (crowd applauds)
```